### PR TITLE
Add Docker Desktop setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,41 @@ This makes it easier to run the project without manually typing commands.
 
 ---
 
+## 🐳 Running with Docker Desktop
+
+If you prefer not to install Node.js locally you can run the whole stack with
+Docker Desktop. The repository now includes a `docker-compose.yml` file that
+starts both the API and the web application in two containers (Node.js for the
+API and Nginx for the built frontend).
+
+1. **Prepare an assets folder on your machine** (for example
+   `C:\AssetsLibrary`). The backend will read-only mount this folder inside the
+   container. Place a few test files inside to verify everything works.
+2. **Clone the repository** and open a terminal in its root.
+3. **Adjust the volume mapping if necessary.** By default the compose file maps
+   a local `./assets` directory. You can either create that directory next to
+   the compose file or edit the `volumes` entry so it points to your own folder
+   (e.g. `C:\\AssetsLibrary:/assets:ro`).
+4. **Launch the stack** with Docker Desktop:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   The command builds the backend and frontend images, installs all
+   dependencies, and starts both services.
+
+5. **Open the application** in your browser at [http://localhost:8080](http://localhost:8080).
+   The frontend is served by Nginx and proxies `/api` and `/files` to the
+   backend container, so the UI works without additional configuration.
+6. **Stop the containers** at any time with `Ctrl+C` in the terminal or by
+   running `docker compose down` in another shell.
+
+> **Note:** If you update the source code, re-run `docker compose up --build` so
+> Docker rebuilds the images with your changes.
+
+---
+
 ## 🔧 Backend (API)
 
 * Located in the **`backend/`** folder.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  server:
+    build:
+      context: .
+      dockerfile: docker/backend/Dockerfile
+    environment:
+      PORT: 5174
+      ASSETS_ROOT: /assets
+    volumes:
+      - ./assets:/assets:ro
+    expose:
+      - "5174"
+  web:
+    build:
+      context: .
+      dockerfile: docker/frontend/Dockerfile
+    depends_on:
+      - server
+    ports:
+      - "8080:80"

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,0 +1,17 @@
+# Backend service Dockerfile
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+# Install production dependencies
+COPY server/package*.json ./
+RUN npm ci --omit=dev
+
+# Copy source code
+COPY server/. ./
+
+ENV NODE_ENV=production
+
+EXPOSE 5174
+
+CMD ["npm", "run", "start"]

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,0 +1,17 @@
+# Frontend build and runtime Dockerfile
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY web/package*.json ./
+RUN npm ci
+
+COPY web/. ./
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,29 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://server:5174;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /files/ {
+        proxy_pass http://server:5174;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add a docker-compose configuration to run the API and frontend behind nginx
- provide Dockerfiles for building the backend and frontend containers
- document simple Docker Desktop usage steps in the README

## Testing
- not run (Docker CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4f8ff5fac8323836c50a4d2feedf3